### PR TITLE
Add roundup as new tracker

### DIFF
--- a/bountysource.raml
+++ b/bountysource.raml
@@ -75,7 +75,8 @@ routes:
             "lanchpad",
             "pivotal",
             "sourceforge",
-            "trac" ]
+            "trac",
+            "roundup" ]
 
         featured:
           displayName: Featured
@@ -174,7 +175,8 @@ routes:
             "lanchpad",
             "pivotal",
             "sourceforge",
-            "trac" ]
+            "trac",
+            "roundup" ]
           example: github
         can_add_bounty:
           displayName: Opened/Closed


### PR DESCRIPTION
Related to bountysource/frontend/issues/927

Roundup is used as a issue tracker for several projects. Some examples are:
- Python Issue tracker:  http://bugs.python.org/
- Jython Issue tracker: http://bugs.jython.org/
- Tryton Issue tracker: https://bugs.tryton.org/

It can be accessed through xml-rpc as described on: http://roundup.sourceforge.net/docs/xmlrpc.html

Feel free to ask anything required to implement the API
